### PR TITLE
Fix Column.ToArray<T> typecast error (fixes #4)

### DIFF
--- a/FeatherDotNet/Column.cs
+++ b/FeatherDotNet/Column.cs
@@ -288,7 +288,11 @@ namespace FeatherDotNet
 
             if (CanBeBlitted<T>())
             {
-                Parent.UnsafeFastGetRowRange<T>(translatedIndex, TranslatedColumnIndex, array, destinationIndex, length);
+                if (typeof(T) == Type) {
+                    Parent.UnsafeFastGetRowRange<T>(translatedIndex, TranslatedColumnIndex, array, destinationIndex, length);
+                } else {
+                    Parent.GetRowRangeWithTypeCast<T>(translatedIndex, TranslatedColumnIndex, array, destinationIndex, length);
+                }
                 return;
             }
 

--- a/FeatherDotNet/DataFrame.cs
+++ b/FeatherDotNet/DataFrame.cs
@@ -456,7 +456,7 @@ namespace FeatherDotNet
                 case ColumnType.Double: uncastedArray = ReadNativeArrayUnsafe<System.Double>(byteIndex, length); break;
                 default: throw new InvalidOperationException($"Invalid cast {columnMetadata.Name}: {columnMetadata.Type} -> {typeof(T)}");
             }
-            Array.Copy(uncastedArray, array, length);
+            Array.Copy(uncastedArray, 0, array, destinationIndex, length);
         }
 
         internal bool IsNullTranslated(long translatedRowIndex, long translatedColumnIndex)

--- a/FeatherDotNet/DataFrame.cs
+++ b/FeatherDotNet/DataFrame.cs
@@ -427,6 +427,38 @@ namespace FeatherDotNet
             UnsafeArrayReader<T>.ReadArray(View, byteIndex, array, 0, length);
         }
 
+        private Array ReadNativeArrayUnsafe<T>(long byteIndex, int length) {
+            T[] array = new T[length];
+            UnsafeArrayReader<T>.ReadArray(View, byteIndex, array, 0, length);
+            return array;
+        }
+
+        internal void GetRowRangeWithTypeCast<T>(long translatedRowIndex, long translatedColumnIndex, T[] array, int destinationIndex, int length)
+        {
+            var columnMetadata = Metadata.Columns[translatedColumnIndex];
+            var entrySize = columnMetadata.Type.GetAlignment();
+            var dataStart = columnMetadata.DataOffset;
+            var byteOffset = translatedRowIndex * entrySize;
+
+            var byteIndex = dataStart + byteOffset;
+
+            Array uncastedArray;
+            switch (columnMetadata.Type) {
+                case ColumnType.Int8:   uncastedArray = ReadNativeArrayUnsafe<System.SByte> (byteIndex, length); break;
+                case ColumnType.Int16:  uncastedArray = ReadNativeArrayUnsafe<System.Int16> (byteIndex, length); break;
+                case ColumnType.Int32:  uncastedArray = ReadNativeArrayUnsafe<System.Int32> (byteIndex, length); break;
+                case ColumnType.Int64:  uncastedArray = ReadNativeArrayUnsafe<System.Int64> (byteIndex, length); break;
+                case ColumnType.Uint8:  uncastedArray = ReadNativeArrayUnsafe<System.Byte>  (byteIndex, length); break;
+                case ColumnType.Uint16: uncastedArray = ReadNativeArrayUnsafe<System.UInt16>(byteIndex, length); break;
+                case ColumnType.Uint32: uncastedArray = ReadNativeArrayUnsafe<System.UInt32>(byteIndex, length); break;
+                case ColumnType.Uint64: uncastedArray = ReadNativeArrayUnsafe<System.UInt64>(byteIndex, length); break;
+                case ColumnType.Float:  uncastedArray = ReadNativeArrayUnsafe<System.Single>(byteIndex, length); break;
+                case ColumnType.Double: uncastedArray = ReadNativeArrayUnsafe<System.Double>(byteIndex, length); break;
+                default: throw new InvalidOperationException($"Invalid cast {columnMetadata.Name}: {columnMetadata.Type} -> {typeof(T)}");
+            }
+            Array.Copy(uncastedArray, array, length);
+        }
+
         internal bool IsNullTranslated(long translatedRowIndex, long translatedColumnIndex)
         {
             var columnMetadata = Metadata.Columns[translatedColumnIndex];


### PR DESCRIPTION
This is my own workaround for the typecast issue.

It appears that `CanBeBlitted<T>` is not a sufficient condition for direct byte-copy to target array - types should match as well.

I have added some additional code to detect the mismatch condition and copy the data through an intermediate array (builtin `Array.Copy` seems to do the correct thing).

This is probably not as performant as generated IL, but at least it works without errors.