### PR TITLE
Add uint -> int casts

### DIFF
--- a/FeatherDotNet/Impl/ColumnSpec.cs
+++ b/FeatherDotNet/Impl/ColumnSpec.cs
@@ -312,7 +312,7 @@ namespace FeatherDotNet.Impl
                     return toType == typeof(long) || toType == typeof(long?) || toType == typeof(int) || toType == typeof(int?) || toType == typeof(short) || toType == typeof(short?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
 
                 case ColumnType.Uint16:
-                    return toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(ushort) || toType == typeof(ushort?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
+                    return toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(ushort) || toType == typeof(ushort?) || toType == typeof(int) || toType == typeof(uint) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
 
                 case ColumnType.Int32:
                     return toType == typeof(long) || toType == typeof(long?) || toType == typeof(int) || toType == typeof(int?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
@@ -330,7 +330,7 @@ namespace FeatherDotNet.Impl
                     return toType == typeof(sbyte) || toType == typeof(sbyte?) || toType == typeof(long) || toType == typeof(long?) || toType == typeof(int) || toType == typeof(int?) || toType == typeof(short) || toType == typeof(short?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
 
                 case ColumnType.Uint8:
-                    return toType == typeof(byte) || toType == typeof(byte?) || toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(ushort) || toType == typeof(ushort?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
+                    return toType == typeof(byte) || toType == typeof(byte?) || toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(ushort) || toType == typeof(ushort?) || toType == typeof(int) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
 
                 case ColumnType.NullableBool:
                     return toType == typeof(bool?);

--- a/FeatherDotNet/Impl/ColumnSpec.cs
+++ b/FeatherDotNet/Impl/ColumnSpec.cs
@@ -312,13 +312,15 @@ namespace FeatherDotNet.Impl
                     return toType == typeof(long) || toType == typeof(long?) || toType == typeof(int) || toType == typeof(int?) || toType == typeof(short) || toType == typeof(short?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
 
                 case ColumnType.Uint16:
-                    return toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(ushort) || toType == typeof(ushort?) || toType == typeof(int) || toType == typeof(uint) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
+                    return toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(ushort) || toType == typeof(ushort?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?) ||
+                           toType == typeof(long)  || toType == typeof(long?)  || toType == typeof(int)  || toType == typeof(int?);
 
                 case ColumnType.Int32:
                     return toType == typeof(long) || toType == typeof(long?) || toType == typeof(int) || toType == typeof(int?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
 
                 case ColumnType.Uint32:
-                    return toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
+                    return toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?) ||
+                           toType == typeof(long) || toType == typeof(long?);
 
                 case ColumnType.Int64:
                     return toType == typeof(long) || toType == typeof(long?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
@@ -330,7 +332,8 @@ namespace FeatherDotNet.Impl
                     return toType == typeof(sbyte) || toType == typeof(sbyte?) || toType == typeof(long) || toType == typeof(long?) || toType == typeof(int) || toType == typeof(int?) || toType == typeof(short) || toType == typeof(short?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
 
                 case ColumnType.Uint8:
-                    return toType == typeof(byte) || toType == typeof(byte?) || toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(ushort) || toType == typeof(ushort?) || toType == typeof(int) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
+                    return toType == typeof(byte) || toType == typeof(byte?) || toType == typeof(ulong) || toType == typeof(ulong?) || toType == typeof(uint) || toType == typeof(uint?) || toType == typeof(ushort) || toType == typeof(ushort?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?) ||
+                           toType == typeof(long) || toType == typeof(long?) || toType == typeof(int) || toType == typeof(int?) || toType == typeof(short) || toType == typeof(short?);
 
                 case ColumnType.NullableBool:
                     return toType == typeof(bool?);
@@ -352,13 +355,15 @@ namespace FeatherDotNet.Impl
                     return toType == typeof(long?) || toType == typeof(int?) || toType == typeof(short?) || toType == typeof(float?) || toType == typeof(double?);
 
                 case ColumnType.NullableUint16:
-                    return toType == typeof(ulong?) || toType == typeof(uint?) || toType == typeof(ushort?) || toType == typeof(float?) || toType == typeof(double?);
+                    return toType == typeof(ulong?) || toType == typeof(uint?) || toType == typeof(ushort?) || toType == typeof(float?) || toType == typeof(double?) ||
+                           toType == typeof(long?) || toType == typeof(int?);
 
                 case ColumnType.NullableInt32:
                     return toType == typeof(long?) || toType == typeof(int?) || toType == typeof(float?) || toType == typeof(double?);
 
                 case ColumnType.NullableUint32:
-                    return toType == typeof(ulong?) || toType == typeof(uint?) || toType == typeof(float?) || toType == typeof(double?);
+                    return toType == typeof(ulong?) || toType == typeof(uint?) || toType == typeof(float?) || toType == typeof(double?) ||
+                           toType == typeof(long?);
 
                 case ColumnType.NullableInt64:
                     return toType == typeof(long?) || toType == typeof(float?) || toType == typeof(double?);
@@ -370,7 +375,8 @@ namespace FeatherDotNet.Impl
                     return toType == typeof(sbyte?) || toType == typeof(long?) || toType == typeof(int?) || toType == typeof(short?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
 
                 case ColumnType.NullableUint8:
-                    return toType == typeof(byte?) || toType == typeof(ulong?) || toType == typeof(uint?) || toType == typeof(ushort?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?);
+                    return toType == typeof(byte?) || toType == typeof(ulong?) || toType == typeof(uint?) || toType == typeof(ushort?) || toType == typeof(float) || toType == typeof(float?) || toType == typeof(double) || toType == typeof(double?) ||
+                           toType == typeof(long?) || toType == typeof(int?) || toType == typeof(short?);
 
                 case ColumnType.String:
                 case ColumnType.NullableString:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See the [test project](https://github.com/kevin-montrose/FeatherDotNet/FeatherDo
 ## Type Mappings
 
 Integer types can be freely converted provided the underlying type is at least as large as the .NET type (an `Int16` can be mapped to an `int`,
-but and `Int64` may not be mapped to a `int`) and the signedness is the same (a `UInt16` cannot be mapped to an `int`).
+but `Int64` may not be mapped to a `int`) and respects signedness (a `UInt16` can be mapped into `int`, whereas `Int16` can't be mapped into `uint` due to possible loss of sign).
 
 For floating point values, `float` and `double` are supported target types (`decimal` is not).  All integer types can be converted to `float` or `double`.
 If the underlying type is a `Double` it cannot be converted to a `float`, but `Single`s can be converted to `double`s.


### PR DESCRIPTION
FeatherDotNet won't allow casting `uint16` into `int`.

I've added some code to allow `uint8` and `uint16` to `int` (and `uint32` to `long`) conversions since in this case there's no danger of loosing any data (e.g. 8- and 16-bit unsigned will safely fit into 32-bits).
